### PR TITLE
Add modular simulator with CLI main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 Este repositorio contiene un ejemplo simple para simular la marcha tipo de un BRT basándose en un modelo de seguimiento de vehículos (car-following). Utiliza el Modelo de Conductor Inteligente (IDM) para calcular la aceleración del vehículo seguidor.
 
-El script `marche_type.py` genera una lista de posiciones y velocidades para el vehículo a intervalos de medio segundo. Se puede ejecutar directamente con Python:
+El código se organiza en varios módulos y puede ejecutarse con `main.py`.
+Para obtener la trayectoria simulada se ejecuta:
 
 ```bash
-python3 marche_type.py
+python3 main.py
 ```
 
-El resultado es una serie de pares `distancia, velocidad` que representan la trayectoria simulada.
+El resultado es una serie de pares `distancia, velocidad`.
+
+Para generar gráficas de la marcha tipo con varias estaciones (requiere `matplotlib`):
+
+```bash
+python3 main.py --plot
+```
+
+Se mostrarán las curvas de **velocidad contra distancia** y **velocidad contra tiempo** para un recorrido con paradas de 30 segundos en cada estación.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+import argparse
+from marche_type import IDMParameters, VehicleState, MarcheTypeSimulator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run marche type simulations")
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="plot a sample route with stops",
+    )
+    args = parser.parse_args()
+
+    params = IDMParameters(v0=15.0, T=1.5, a=0.6, b=1.5, s0=2.0)
+    sim = MarcheTypeSimulator(params)
+
+    if args.plot:
+        t, x, v = sim.simulate_route([0, 300, 800, 1500], dwell_time=30.0)
+        try:
+            sim.plot_speed_profiles(t, x, v)
+        except ImportError as exc:
+            print("Plotting unavailable:", exc)
+    else:
+        data = sim.simulate_idm(
+            lead_init=VehicleState(x=50.0, v=10.0),
+            follower_init=VehicleState(x=0.0, v=0.0),
+            steps=120,
+            lead_speed=10.0,
+        )
+        for distance, speed in data:
+            print(f"{distance:.2f}, {speed:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marche_type.py
+++ b/marche_type.py
@@ -1,6 +1,13 @@
+"""Core library for simulating a BRT marche type using IDM."""
+
 import math
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Iterable, List, Sequence, Tuple
+
+try:  # optional dependency for plotting
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib may not be installed
+    plt = None
 
 @dataclass
 class VehicleState:
@@ -25,6 +32,98 @@ def idm_acceleration(lead: VehicleState, follower: VehicleState, params: IDMPara
     s_star = params.s0 + max(0.0, follower.v * params.T + (follower.v * dv) / (2 * math.sqrt(params.a * params.b)))
     return params.a * (1 - (follower.v / params.v0) ** params.delta - (s_star / s) ** 2)
 
+
+class MarcheTypeSimulator:
+    """Encapsulates IDM-based simulations and optional plotting."""
+
+    def __init__(self, params: IDMParameters, dt: float = 0.5) -> None:
+        self.params = params
+        self.dt = dt
+
+    def simulate_idm(
+        self,
+        lead_init: VehicleState,
+        follower_init: VehicleState,
+        steps: int,
+        lead_speed: float,
+    ) -> List[Tuple[float, float]]:
+        """Simulate follower using IDM. Returns list of (distance, speed)."""
+        lead = VehicleState(lead_init.x, lead_init.v)
+        follower = VehicleState(follower_init.x, follower_init.v)
+        result: List[Tuple[float, float]] = []
+        for _ in range(steps):
+            lead.v = lead_speed
+            lead.x += lead.v * self.dt
+
+            a = idm_acceleration(lead, follower, self.params)
+            follower.v = max(0.0, follower.v + a * self.dt)
+            follower.x += follower.v * self.dt
+            result.append((follower.x, follower.v))
+        return result
+
+    def simulate_route(
+        self,
+        stations: Sequence[float],
+        dwell_time: float,
+        accel: float = 0.7,
+        decel: float = 0.7,
+        v_max: float = 20.0,
+    ) -> Tuple[List[float], List[float], List[float]]:
+        """Generate a speed profile for a route with stops."""
+        time = [0.0]
+        pos = [stations[0]]
+        vel = [0.0]
+        t = 0.0
+        x = stations[0]
+        v = 0.0
+        for idx in range(1, len(stations)):
+            target = stations[idx]
+            while x < target:
+                dist_left = target - x
+                stopping_dist = v ** 2 / (2 * decel)
+                if dist_left <= stopping_dist:
+                    v = max(0.0, v - decel * self.dt)
+                else:
+                    if v < v_max:
+                        v = min(v_max, v + accel * self.dt)
+                x += v * self.dt
+                t += self.dt
+                time.append(t)
+                pos.append(x)
+                vel.append(v)
+            x = target
+            time.append(t)
+            pos.append(x)
+            vel.append(0.0)
+            for _ in range(int(dwell_time / self.dt)):
+                t += self.dt
+                time.append(t)
+                pos.append(x)
+                vel.append(0.0)
+            v = 0.0
+        return time, pos, vel
+
+    def plot_speed_profiles(
+        self, time: Iterable[float], pos: Iterable[float], vel: Iterable[float]
+    ) -> None:
+        """Plot speed-distance and speed-time graphs if matplotlib is available."""
+        if plt is None:
+            raise ImportError("matplotlib is required for plotting")
+        plt.figure(figsize=(10, 6))
+        plt.subplot(2, 1, 1)
+        plt.plot(pos, vel)
+        plt.xlabel("Distancia (m)")
+        plt.ylabel("Velocidad (m/s)")
+        plt.title("Velocidad vs Distancia")
+
+        plt.subplot(2, 1, 2)
+        plt.plot(time, vel)
+        plt.xlabel("Tiempo (s)")
+        plt.ylabel("Velocidad (m/s)")
+        plt.title("Velocidad vs Tiempo")
+        plt.tight_layout()
+        plt.show()
+
 def simulate_marche_type(
     lead_init: VehicleState,
     follower_init: VehicleState,
@@ -33,19 +132,14 @@ def simulate_marche_type(
     steps: int,
     lead_speed: float,
 ) -> List[Tuple[float, float]]:
-    """Simulate follower using IDM. Returns list of (distance, speed)."""
-    lead = VehicleState(lead_init.x, lead_init.v)
-    follower = VehicleState(follower_init.x, follower_init.v)
-    result = []
-    for _ in range(steps):
-        lead.v = lead_speed  # keep lead vehicle at constant speed
-        lead.x += lead.v * dt
-
-        a = idm_acceleration(lead, follower, params)
-        follower.v = max(0.0, follower.v + a * dt)
-        follower.x += follower.v * dt
-        result.append((follower.x, follower.v))
-    return result
+    """Backward compatible helper that delegates to :class:`MarcheTypeSimulator`."""
+    simulator = MarcheTypeSimulator(params, dt)
+    return simulator.simulate_idm(
+        lead_init=lead_init,
+        follower_init=follower_init,
+        steps=steps,
+        lead_speed=lead_speed,
+    )
 
 if __name__ == "__main__":
     params = IDMParameters(v0=15.0, T=1.5, a=0.6, b=1.5, s0=2.0)
@@ -55,6 +149,12 @@ if __name__ == "__main__":
     steps = 120  # simulate 1 minute
     lead_speed = 10.0
 
-    data = simulate_marche_type(lead_init, follower_init, params, dt, steps, lead_speed)
+    simulator = MarcheTypeSimulator(params, dt)
+    data = simulator.simulate_idm(
+        lead_init=lead_init,
+        follower_init=follower_init,
+        steps=steps,
+        lead_speed=lead_speed,
+    )
     for distance, speed in data:
         print(f"{distance:.2f}, {speed:.2f}")

--- a/marche_type_plot.py
+++ b/marche_type_plot.py
@@ -1,0 +1,16 @@
+from typing import Sequence
+
+from marche_type import MarcheTypeSimulator, IDMParameters
+
+
+def plot_example_route(stations: Sequence[float], dwell: float) -> None:
+    """Run a simple route simulation and plot the results."""
+    params = IDMParameters(v0=15.0, T=1.5, a=0.6, b=1.5, s0=2.0)
+    sim = MarcheTypeSimulator(params)
+    t, x, v = sim.simulate_route(stations, dwell)
+    sim.plot_speed_profiles(t, x, v)
+
+
+if __name__ == "__main__":
+    plot_example_route([0, 300, 800, 1500], 30.0)
+


### PR DESCRIPTION
## Summary
- refactor `marche_type.py` into a reusable module with `MarcheTypeSimulator`
- update plotting script to use the new simulator
- provide a `main.py` entry point with a `--plot` option
- document the new usage in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 marche_type.py | head -n 5`
- `python3 main.py --plot` *(fails: matplotlib is required)*

------
https://chatgpt.com/codex/tasks/task_e_686cbc73ac488333b00a913c03466451